### PR TITLE
Sidebar Confusion

### DIFF
--- a/apps/builder/pages/admin/index.tsx
+++ b/apps/builder/pages/admin/index.tsx
@@ -8,8 +8,12 @@ import {
 import { useStore } from '@codelab/frontend/presenter/container'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   commonMenuItems,
   ContentSection,
+  pageBuilderMenuItem,
+  resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -49,13 +53,23 @@ export const getServerSideProps = auth0Instance.withPageAuthRequired()
 
 AdminPage.Layout = (page) => {
   const AdminHeader = () => <PageHeader ghost={false} title="Admin" />
+  const { userService } = useStore()
 
   return (
     <DashboardTemplate
       Header={AdminHeader}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={commonMenuItems}
+          primaryItems={[
+            ...(commonMenuItems ?? []),
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/apps/[appId]/domains/index.tsx
+++ b/apps/builder/pages/apps/[appId]/domains/index.tsx
@@ -15,8 +15,12 @@ import {
 import { useStatefulExecutor } from '@codelab/frontend/shared/utils'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
   ContentSection,
+  pageBuilderMenuItem,
+  resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -97,12 +101,23 @@ export default DomainsPage
 export const getServerSideProps = auth0Instance.withPageAuthRequired()
 
 DomainsPage.Layout = (page) => {
+  const { userService } = useStore()
+
   return (
     <DashboardTemplate
       Header={DomainsPageHeader}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -9,14 +9,18 @@ import {
 } from '@codelab/frontend/modules/builder'
 import { PageDetailHeader } from '@codelab/frontend/modules/page'
 import {
+  useCurrentAppId,
   useCurrentPageId,
   useStore,
 } from '@codelab/frontend/presenter/container'
 import { useStatefulExecutor } from '@codelab/frontend/shared/utils'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
+  pageBuilderMenuItem,
   resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -24,7 +28,7 @@ import {
 } from '@codelab/frontend/view/templates'
 import { observer } from 'mobx-react-lite'
 import Head from 'next/head'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 const PageBuilder: CodelabPage = observer(() => {
   const store = useStore()
@@ -72,9 +76,15 @@ PageBuilder.Layout = observer((page) => {
     actionService,
   } = useStore()
 
+  const appId = useCurrentAppId()
   const pageId = useCurrentPageId()
   const pageBuilderRenderer = builderRenderService.renderers.get(pageId)
   const activeElementTree = builderService.activeElementTree
+
+  useEffect(() => {
+    userService.user?.setCurAppId(appId)
+    userService.user?.setCurPageId(pageId)
+  }, [appId, pageId])
 
   return (
     <BuilderContext
@@ -119,7 +129,13 @@ PageBuilder.Layout = observer((page) => {
         ))}
         SidebarNavigation={() => (
           <SidebarNavigation
-            primaryItems={[appMenuItem, resourceMenuItem]}
+            primaryItems={[
+              appMenuItem,
+              allPagesMenuItem(appId),
+              pageBuilderMenuItem(appId, pageId),
+              storeMenuItem(appId),
+              resourceMenuItem,
+            ]}
             secondaryItems={adminMenuItems}
             // activeBuilderTab={builderService.activeBuilderTab}
             // key={pageBuilderRenderer?.pageTree?.current.root?.id}

--- a/apps/builder/pages/apps/[appId]/pages/index.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/index.tsx
@@ -8,7 +8,10 @@ import {
 } from '@codelab/frontend/presenter/container'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
+  pageBuilderMenuItem,
+  resourceMenuItem,
   storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
@@ -18,7 +21,7 @@ import {
 } from '@codelab/frontend/view/templates'
 import { observer } from 'mobx-react-lite'
 import Head from 'next/head'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 const Pages: CodelabPage<DashboardTemplateProps> = observer(() => {
   const store = useStore()
@@ -38,15 +41,28 @@ export default Pages
 export const getServerSideProps = auth0Instance.withPageAuthRequired()
 
 Pages.Layout = observer((page) => {
-  const store = useStore()
+  const { userService, pageService } = useStore()
   const appId = useCurrentAppId()
+
+  useEffect(() => {
+    userService.user?.setCurAppId(appId)
+  }, [appId])
 
   return (
     <DashboardTemplate
-      ExplorerPane={() => <ExplorerPanePage pageService={store.pageService} />}
+      ExplorerPane={() => <ExplorerPanePage pageService={pageService} />}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem, storeMenuItem(appId)]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(appId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(appId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/apps/[appId]/store.tsx
+++ b/apps/builder/pages/apps/[appId]/store.tsx
@@ -21,7 +21,14 @@ import {
   useStatefulExecutor,
 } from '@codelab/frontend/shared/utils'
 import { DisplayIf } from '@codelab/frontend/view/components'
-import { adminMenuItems, appMenuItem } from '@codelab/frontend/view/sections'
+import {
+  adminMenuItems,
+  allPagesMenuItem,
+  appMenuItem,
+  pageBuilderMenuItem,
+  resourceMenuItem,
+  storeMenuItem,
+} from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
   SidebarNavigation,
@@ -108,7 +115,8 @@ const StorePage: CodelabPage = observer(() => {
 export const getServerSideProps = auth0Instance.withPageAuthRequired({})
 
 StorePage.Layout = observer((page) => {
-  const { actionService, appService, typeService, storeService } = useStore()
+  const { actionService, appService, typeService, storeService, userService } =
+    useStore()
 
   return (
     <DashboardTemplate
@@ -129,7 +137,16 @@ StorePage.Layout = observer((page) => {
       )}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/apps/index.tsx
+++ b/apps/builder/pages/apps/index.tsx
@@ -13,8 +13,12 @@ import { useStore } from '@codelab/frontend/presenter/container'
 import { useStatefulExecutor } from '@codelab/frontend/shared/utils'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
   ContentSection,
+  pageBuilderMenuItem,
+  resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -88,12 +92,23 @@ export default AppsPage
 export const getServerSideProps = auth0Instance.withPageAuthRequired()
 
 AppsPage.Layout = (page) => {
+  const { userService } = useStore()
+
   return (
     <DashboardTemplate
       Header={AppsPageHeader}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/atoms/index.tsx
+++ b/apps/builder/pages/atoms/index.tsx
@@ -11,8 +11,12 @@ import { useStore } from '@codelab/frontend/presenter/container'
 import { useStatefulExecutor } from '@codelab/frontend/shared/utils'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
   ContentSection,
+  pageBuilderMenuItem,
+  resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -87,12 +91,23 @@ export const getServerSideProps = auth0Instance.withPageAuthRequired({
 })
 
 AtomsPage.Layout = (page) => {
+  const { userService } = useStore()
+
   return (
     <DashboardTemplate
       Header={Header}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/resources/index.tsx
+++ b/apps/builder/pages/resources/index.tsx
@@ -10,9 +10,12 @@ import {
 import { useStore } from '@codelab/frontend/presenter/container'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
   ContentSection,
+  pageBuilderMenuItem,
   resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -65,12 +68,23 @@ export default ResourcesPage
 export const getServerSideProps = auth0Instance.withPageAuthRequired()
 
 ResourcesPage.Layout = observer((resource) => {
+  const { userService } = useStore()
+
   return (
     <DashboardTemplate
       Header={ResourcesPageHeader}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem, resourceMenuItem]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/tags/index.tsx
+++ b/apps/builder/pages/tags/index.tsx
@@ -13,8 +13,12 @@ import { useStore } from '@codelab/frontend/presenter/container'
 import { useStatefulExecutor } from '@codelab/frontend/shared/utils'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
   ContentSection,
+  pageBuilderMenuItem,
+  resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -64,15 +68,24 @@ const TagPageHeader = observer(() => {
 export default TagPage
 
 TagPage.Layout = observer((page) => {
-  const store = useStore()
+  const { tagService, userService } = useStore()
 
   return (
     <DashboardTemplate
-      ExplorerPane={() => <GetTagsTree tagService={store.tagService} />}
+      ExplorerPane={() => <GetTagsTree tagService={tagService} />}
       Header={TagPageHeader}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/types/index.tsx
+++ b/apps/builder/pages/types/index.tsx
@@ -10,8 +10,12 @@ import {
 import { useStore } from '@codelab/frontend/presenter/container'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
   ContentSection,
+  pageBuilderMenuItem,
+  resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -67,12 +71,23 @@ export default TypesPage
 export const getServerSideProps = auth0Instance.withPageAuthRequired()
 
 TypesPage.Layout = observer((page) => {
+  const { userService } = useStore()
+
   return (
     <DashboardTemplate
       Header={Header}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/apps/builder/pages/types/interfaces/[interfaceId]/index.tsx
+++ b/apps/builder/pages/types/interfaces/[interfaceId]/index.tsx
@@ -12,8 +12,12 @@ import {
 import { useStore } from '@codelab/frontend/presenter/container'
 import {
   adminMenuItems,
+  allPagesMenuItem,
   appMenuItem,
   ContentSection,
+  pageBuilderMenuItem,
+  resourceMenuItem,
+  storeMenuItem,
 } from '@codelab/frontend/view/sections'
 import {
   DashboardTemplate,
@@ -91,12 +95,23 @@ export default InterfaceDetailPage
 export const getServerSideProps = auth0Instance.withPageAuthRequired()
 
 InterfaceDetailPage.Layout = observer((page) => {
+  const { userService } = useStore()
+
   return (
     <DashboardTemplate
       Header={Header}
       SidebarNavigation={() => (
         <SidebarNavigation
-          primaryItems={[appMenuItem]}
+          primaryItems={[
+            appMenuItem,
+            allPagesMenuItem(userService.user?.curAppId),
+            pageBuilderMenuItem(
+              userService.user?.curAppId,
+              userService.user?.curPageId,
+            ),
+            storeMenuItem(userService.user?.curAppId),
+            resourceMenuItem,
+          ]}
           secondaryItems={adminMenuItems}
         />
       )}

--- a/libs/frontend/modules/user/src/store/user.model.ts
+++ b/libs/frontend/modules/user/src/store/user.model.ts
@@ -1,6 +1,7 @@
 import { appRef } from '@codelab/frontend/modules/app'
 import type { IApp, IUser, IUserDTO } from '@codelab/shared/abstract/core'
 import { IRole } from '@codelab/shared/abstract/core'
+import { Nullable } from '@codelab/shared/abstract/types'
 import {
   detach,
   idProp,
@@ -38,6 +39,8 @@ export class User
     auth0Id: prop<string>(),
     roles: prop<Array<IRole>>(() => []),
     apps: prop<Array<Ref<IApp>>>(() => []),
+    curAppId: prop<Nullable<string>>(null).withSetter(),
+    curPageId: prop<Nullable<string>>(null).withSetter(),
   })
   implements IUser
 {

--- a/libs/frontend/view/sections/Menu/commonMenuItems.tsx
+++ b/libs/frontend/view/sections/Menu/commonMenuItems.tsx
@@ -1,9 +1,12 @@
 import {
   AppstoreOutlined,
+  BuildOutlined,
   CloudServerOutlined,
   DatabaseOutlined,
+  FileOutlined,
 } from '@ant-design/icons'
 import { PageType } from '@codelab/frontend/abstract/types'
+import { Nullish } from '@codelab/shared/abstract/types'
 import { MenuProps } from 'antd'
 import { ItemType } from 'antd/lib/menu/hooks/useItems'
 import Link from 'next/link'
@@ -15,9 +18,10 @@ export const appMenuItem: ItemType = {
   label: <Link href={PageType.AppList}>Apps</Link>,
 }
 
-export const storeMenuItem = (appId: string): ItemType => ({
+export const storeMenuItem = (appId: Nullish<string>): ItemType => ({
   icon: <DatabaseOutlined data-testid="store-tab-trigger" title="Store" />,
   key: PageType.Store,
+  disabled: !appId,
   label: (
     <Link href={{ pathname: PageType.Store, query: { appId } }}>Store</Link>
   ),
@@ -30,6 +34,29 @@ export const resourceMenuItem: ItemType = {
   key: PageType.Resource,
   label: <Link href={PageType.Resource}>Resources</Link>,
 }
+
+export const allPagesMenuItem = (appId: Nullish<string>): ItemType => ({
+  icon: <FileOutlined data-testid="pages-tab-trigger" title="Pages" />,
+  key: PageType.PageList,
+  disabled: !appId,
+  label: (
+    <Link href={{ pathname: PageType.PageList, query: { appId } }}>Pages</Link>
+  ),
+})
+
+export const pageBuilderMenuItem = (
+  appId: Nullish<string>,
+  pageId: Nullish<string>,
+): ItemType => ({
+  icon: <BuildOutlined data-testid="builder-tab-trigger" title="Builder" />,
+  key: PageType.PageBuilder,
+  disabled: !appId || !pageId,
+  label: (
+    <Link href={{ pathname: PageType.PageBuilder, query: { appId, pageId } }}>
+      Builder
+    </Link>
+  ),
+})
 
 export const commonMenuItems: MenuProps['items'] = [
   appMenuItem,

--- a/libs/shared/abstract/core/src/domain/user/user.interface.ts
+++ b/libs/shared/abstract/core/src/domain/user/user.interface.ts
@@ -1,3 +1,4 @@
+import { Nullable } from '@codelab/shared/abstract/types'
 import { Ref } from 'mobx-keystone'
 import { IApp } from '../app'
 import { IRole } from './role.enum'
@@ -9,6 +10,10 @@ export interface IUser {
   username: string
   roles: Array<IRole>
   apps: Array<Ref<IApp>>
+  curAppId: Nullable<string>
+  curPageId: Nullable<string>
+  setCurAppId(appId: string): void
+  setCurPageId(pageId: string): void
   // apps: ObjectMap<IApp>
 }
 


### PR DESCRIPTION
## Description
- I opted for having all the items at all times, but if no appId and/or pageId is available, the item would be disabled. I think this would provide a good user experience as users would see the cause and effect of their actions clearly (i.e. when they select an app or page and the sidebar button gets activated).
- The appId and pageId are stored in mobX.

https://user-images.githubusercontent.com/51242349/183489721-c8cc4b32-c135-443c-9c0d-62d0fa3bb53c.mp4

## Related Issue
Fixes #1671
