### PR TITLE
Shortcut to Atom's interface

### DIFF
--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -202,6 +202,7 @@ PageBuilder.Layout = observer((page) => {
                 key={pageBuilderRenderer?.pageTree?.current.root?.id}
                 renderService={pageBuilderRenderer}
                 typeService={typeService}
+                userService={userService}
               />
             ) : null}
           </>

--- a/apps/builder/pages/apps/[appId]/provider.tsx
+++ b/apps/builder/pages/apps/[appId]/provider.tsx
@@ -180,6 +180,7 @@ PageBuilder.Layout = observer((page) => {
                 key={appBuilderRenderer?.pageTree?.current.root?.id}
                 renderService={appBuilderRenderer}
                 typeService={typeService}
+                userService={userService}
               />
             ) : null}
           </>

--- a/libs/frontend/modules/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
+++ b/libs/frontend/modules/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
@@ -28,6 +28,7 @@ import {
   IRenderer,
   isElement,
   ITypeService,
+  IUserService,
 } from '@codelab/shared/abstract/core'
 import { css } from '@emotion/react'
 import { Tabs, Tooltip } from 'antd'
@@ -59,6 +60,7 @@ export type MetaPaneBuilderProps = {
   builderService: IBuilderService
   elementService: IElementService
   actionService: IActionService
+  userService: IUserService
 }
 
 type TooltipIconProps = {
@@ -90,6 +92,7 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
     renderService,
     elementService,
     actionService,
+    userService,
   }) => {
     const selectedNode = builderService.selectedNode
     const { providePropCompletion } = usePropCompletion(renderService)
@@ -146,6 +149,7 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
                   key={selectedNode.id}
                   trackPromises={trackPromises}
                   typeService={typeService}
+                  userService={userService}
                 />
               </>
             ) : (

--- a/libs/frontend/modules/builder/src/sections/config-pane/ConfigPane.tsx
+++ b/libs/frontend/modules/builder/src/sections/config-pane/ConfigPane.tsx
@@ -124,7 +124,7 @@ export const ConfigPane = observer<MetaPaneProps>(
               renderService={renderService}
               typeService={typeService}
               userService={userService}
-      />
+            />
           </Tabs.TabPane>
           <Tabs.TabPane
             destroyInactiveTabPane

--- a/libs/frontend/modules/builder/src/sections/config-pane/ConfigPane.tsx
+++ b/libs/frontend/modules/builder/src/sections/config-pane/ConfigPane.tsx
@@ -17,6 +17,7 @@ import {
   IElementTree,
   IRenderer,
   ITypeService,
+  IUserService,
 } from '@codelab/shared/abstract/core'
 import { Tabs } from 'antd'
 import { observer } from 'mobx-react-lite'
@@ -35,6 +36,7 @@ type MetaPaneProps = {
   elementService: IElementService
   componentService: IComponentService
   actionService: IActionService
+  userService: IUserService
 }
 
 export const ConfigPane = observer<MetaPaneProps>(
@@ -47,6 +49,7 @@ export const ConfigPane = observer<MetaPaneProps>(
     renderService,
     elementTree,
     actionService,
+    userService,
   }) => {
     const { providePropCompletion } = usePropCompletion(renderService)
     const isRootElement = (element: IElement) => !element.parentElement
@@ -120,7 +123,8 @@ export const ConfigPane = observer<MetaPaneProps>(
               elementTree={elementTree}
               renderService={renderService}
               typeService={typeService}
-            />
+              userService={userService}
+      />
           </Tabs.TabPane>
           <Tabs.TabPane
             destroyInactiveTabPane

--- a/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -1,3 +1,5 @@
+import { PlusOutlined } from '@ant-design/icons'
+import { PageType } from '@codelab/frontend/abstract/types'
 import { PropsForm } from '@codelab/frontend/modules/type'
 import { useStatefulExecutor } from '@codelab/frontend/shared/utils'
 import {
@@ -10,9 +12,13 @@ import {
   IElement,
   IElementService,
   IPropData,
+  isAdmin,
   ITypeService,
+  IUserService,
 } from '@codelab/shared/abstract/core'
+import { Button } from 'antd'
 import { observer } from 'mobx-react-lite'
+import Link from 'next/link'
 import { useEffect, useRef } from 'react'
 
 export interface UpdateElementPropsFormProps {
@@ -22,6 +28,7 @@ export interface UpdateElementPropsFormProps {
   trackPromises?: UseTrackLoadingPromises
   autocomplete?: IPropData
   builderState: IBuilderState
+  userService: IUserService
 
   actionList?: Array<IAnyAction>
 }
@@ -35,6 +42,7 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
     typeService,
     autocomplete,
     actionList,
+    userService,
   }) => {
     const { trackPromise } = trackPromises ?? {}
     // cache it to not confuse the user when auto-saving
@@ -83,6 +91,13 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
             onSubmit={onSubmit}
           />
         )}
+        {isAdmin(userService.user) ? (
+          <Link href={PageType.Atom}>
+            <Button>
+              <PlusOutlined />
+            </Button>
+          </Link>
+        ) : null}
       </Spinner>
     )
   },

--- a/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -1,4 +1,3 @@
-import { PlusOutlined } from '@ant-design/icons'
 import { PageType } from '@codelab/frontend/abstract/types'
 import { PropsForm } from '@codelab/frontend/modules/type'
 import { useStatefulExecutor } from '@codelab/frontend/shared/utils'
@@ -16,7 +15,7 @@ import {
   ITypeService,
   IUserService,
 } from '@codelab/shared/abstract/core'
-import { Button } from 'antd'
+import { Col, Row } from 'antd'
 import { observer } from 'mobx-react-lite'
 import Link from 'next/link'
 import React, { useEffect, useRef } from 'react'
@@ -61,7 +60,7 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
       if (apiId) {
         getInterfaceType(apiId)
       }
-    }, [apiId])
+    }, [apiId, getInterfaceType])
 
     const onSubmit = (data: IPropData) => {
       console.log(data)
@@ -82,28 +81,34 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
     return (
       <Spinner isLoading={isLoading}>
         {interfaceType && (
-          <>
-            <PropsForm
-              autosave
-              context={{ autocomplete, builderState, actionList }}
-              initialValue={initialPropsRef.current}
-              interfaceType={interfaceType}
-              key={element.id}
-              onSubmit={onSubmit}
-            />
-            {isAdmin(userService.user) ? (
-              <Link
-                href={{
-                  pathname: PageType.InterfaceDetail,
-                  query: { interfaceId: interfaceType.id },
-                }}
-              >
-                <Button>
-                  <PlusOutlined />
-                </Button>
-              </Link>
-            ) : null}
-          </>
+          <Row gutter={[0, 16]}>
+            <Col span={24}>
+              <PropsForm
+                autosave
+                context={{ autocomplete, builderState, actionList }}
+                initialValue={initialPropsRef.current}
+                interfaceType={interfaceType}
+                key={element.id}
+                onSubmit={onSubmit}
+              />
+            </Col>
+            <Col span={24}>
+              {isAdmin(userService.user) ? (
+                <Row justify="center">
+                  <Col>
+                    <Link
+                      href={{
+                        pathname: PageType.InterfaceDetail,
+                        query: { interfaceId: interfaceType.id },
+                      }}
+                    >
+                      {`Edit ${interfaceType.name}`}
+                    </Link>
+                  </Col>
+                </Row>
+              ) : null}
+            </Col>
+          </Row>
         )}
       </Spinner>
     )

--- a/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -19,7 +19,7 @@ import {
 import { Button } from 'antd'
 import { observer } from 'mobx-react-lite'
 import Link from 'next/link'
-import { useEffect, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 export interface UpdateElementPropsFormProps {
   typeService: ITypeService
@@ -82,22 +82,29 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
     return (
       <Spinner isLoading={isLoading}>
         {interfaceType && (
-          <PropsForm
-            autosave
-            context={{ autocomplete, builderState, actionList }}
-            initialValue={initialPropsRef.current}
-            interfaceType={interfaceType}
-            key={element.id}
-            onSubmit={onSubmit}
-          />
+          <>
+            <PropsForm
+              autosave
+              context={{ autocomplete, builderState, actionList }}
+              initialValue={initialPropsRef.current}
+              interfaceType={interfaceType}
+              key={element.id}
+              onSubmit={onSubmit}
+            />
+            {isAdmin(userService.user) ? (
+              <Link
+                href={{
+                  pathname: PageType.InterfaceDetail,
+                  query: { interfaceId: interfaceType.id },
+                }}
+              >
+                <Button>
+                  <PlusOutlined />
+                </Button>
+              </Link>
+            ) : null}
+          </>
         )}
-        {isAdmin(userService.user) ? (
-          <Link href={PageType.Atom}>
-            <Button>
-              <PlusOutlined />
-            </Button>
-          </Link>
-        ) : null}
       </Spinner>
     )
   },


### PR DESCRIPTION
## Description (Optional)
A shortcut button in props sidebar tab that redirects to the interface of the selected atom.

https://user-images.githubusercontent.com/51242349/183854198-fe7ee3b1-d74d-45f1-9dec-c96c19b65a6b.mp4

## Related Issue(s)
Fixes #1704
