### PR TITLE
InnerHtml Editor Enhanced

### DIFF
--- a/libs/frontend/modules/atom/src/store/atom.model.ts
+++ b/libs/frontend/modules/atom/src/store/atom.model.ts
@@ -6,6 +6,7 @@ import type {
   IAtomType,
   ITag,
 } from '@codelab/shared/abstract/core'
+import { computed } from 'mobx'
 import {
   detach,
   idProp,
@@ -16,6 +17,7 @@ import {
   Ref,
   rootRef,
 } from 'mobx-keystone'
+import { customTextInjectionWhiteList } from './custom-text-injection-whitelist'
 
 const hydrate = (atom: IAtomDTO) => {
   return new Atom({
@@ -38,6 +40,14 @@ export class Atom
   })
   implements IAtom
 {
+  /**
+   * Determines whether the atom accepts children and text make sense for the type.
+   */
+  @computed
+  get allowCustomTextInjection(): boolean {
+    return customTextInjectionWhiteList.indexOf(this.type) > -1
+  }
+
   @modelAction
   updateCache(atom: IAtomDTO) {
     this.name = atom.name

--- a/libs/frontend/modules/atom/src/store/custom-text-injection-whitelist.ts
+++ b/libs/frontend/modules/atom/src/store/custom-text-injection-whitelist.ts
@@ -1,0 +1,42 @@
+import { IAtomType } from '@codelab/shared/abstract/core'
+
+/**
+ * The atoms that are not self closing and need text content to make sense
+ */
+export const customTextInjectionWhiteList = [
+  IAtomType.HtmlA,
+  IAtomType.HtmlAside,
+  IAtomType.HtmlButton,
+  IAtomType.HtmlCode,
+  IAtomType.HtmlDialog,
+  IAtomType.HtmlDiv,
+  IAtomType.HtmlEm,
+  IAtomType.HtmlH1,
+  IAtomType.HtmlH2,
+  IAtomType.HtmlH3,
+  IAtomType.HtmlH4,
+  IAtomType.HtmlH5,
+  IAtomType.HtmlH6,
+  IAtomType.HtmlI,
+  IAtomType.HtmlP,
+  IAtomType.HtmlPre,
+  IAtomType.HtmlS,
+  IAtomType.HtmlSmall,
+  IAtomType.HtmlSpan,
+  IAtomType.HtmlStrong,
+  IAtomType.HtmlSub,
+  IAtomType.HtmlSup,
+  IAtomType.AntDesignButton,
+  IAtomType.AntDesignTypographyParagraph,
+  IAtomType.AntDesignTypographyText,
+  IAtomType.AntDesignTypographyTitle,
+  IAtomType.MuiAlertTitle,
+  IAtomType.MuiButton,
+  IAtomType.MuiButtonBase,
+  IAtomType.MuiButtonUnstyled,
+  IAtomType.MuiDialogTitle,
+  IAtomType.MuiDialogContentText,
+  IAtomType.MuiLink,
+  IAtomType.MuiTypography,
+  IAtomType.Text,
+]

--- a/libs/frontend/modules/element/src/store/element.model.ts
+++ b/libs/frontend/modules/element/src/store/element.model.ts
@@ -186,17 +186,6 @@ export class Element
   // }
 
   @computed
-  get safePropsData(): IPropData {
-    const propsData = { ...this.props?.values }
-
-    if (this.children.size > 0) {
-      delete propsData?.['dangerouslySetInnerHTML']
-    }
-
-    return propsData
-  }
-
-  @computed
   get descendants(): Array<IElement> {
     const descendants: Array<IElement> = []
 

--- a/libs/frontend/modules/element/src/use-cases/element/update-inner-html/UpdateInnerHtmlForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/update-inner-html/UpdateInnerHtmlForm.tsx
@@ -10,7 +10,7 @@ import {
 import { html, htmlCompletionSource } from '@codemirror/lang-html'
 import { Col, Row } from 'antd'
 import { observer } from 'mobx-react-lite'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 export type UpdateInnerHtmlFormProps = {
   elementService: IElementService
@@ -24,6 +24,10 @@ export type UpdateInnerHtmlFormProps = {
 export const UpdateInnerHtmlForm = observer<UpdateInnerHtmlFormProps>(
   ({ elementService, element, trackPromises }) => {
     const { trackPromise } = trackPromises ?? {}
+
+    const [customText, setCustomText] = useState(
+      element.props?.values?.['customText'],
+    )
 
     const inEditMode = useCallback(
       () => element.children.size === 0,
@@ -58,14 +62,15 @@ export const UpdateInnerHtmlForm = observer<UpdateInnerHtmlFormProps>(
             extensions={[html()]}
             height="150px"
             onChange={(newCustomText) => {
+              setCustomText(newCustomText)
               onSubmit({
                 ...element.props?.values,
-                CustomText: newCustomText,
+                customText: newCustomText,
               })
             }}
             shouldDisableNewLines={false}
-            title="CustomText"
-            value={element.props?.values?.['CustomText']}
+            title="customText"
+            value={customText}
           />
         </Col>
       </Row>

--- a/libs/frontend/modules/element/src/use-cases/element/update-inner-html/UpdateInnerHtmlForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/update-inner-html/UpdateInnerHtmlForm.tsx
@@ -44,11 +44,11 @@ export const UpdateInnerHtmlForm = observer<UpdateInnerHtmlFormProps>(
       return trackPromise?.(promise) ?? promise
     }
 
-    return (
+    return element.atom?.current.allowCustomTextInjection ? (
       <Row align="middle">
         <Col span={4}>
           <p style={{ color: inEditMode() ? '#000000' : '#D1D1D1' }}>
-            InnerHtml
+            Custom Text
           </p>
         </Col>
         <Col span={20}>
@@ -57,20 +57,18 @@ export const UpdateInnerHtmlForm = observer<UpdateInnerHtmlFormProps>(
             editable={inEditMode()}
             extensions={[html()]}
             height="150px"
-            onChange={(newInnerHTML) => {
+            onChange={(newCustomText) => {
               onSubmit({
                 ...element.props?.values,
-                dangerouslySetInnerHTML: {
-                  __html: newInnerHTML,
-                },
+                CustomText: newCustomText,
               })
             }}
             shouldDisableNewLines={false}
-            title="InnerHtml"
-            value={element.props?.values?.['dangerouslySetInnerHTML']?.__html}
+            title="CustomText"
+            value={element.props?.values?.['CustomText']}
           />
         </Col>
       </Row>
-    )
+    ) : null
   },
 )

--- a/libs/frontend/modules/renderer/src/element/ElementWrapper.ts
+++ b/libs/frontend/modules/renderer/src/element/ElementWrapper.ts
@@ -48,7 +48,11 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       const hasNoChildren = childrenAreEmpty(children)
 
       // Allow for a 'children' prop, but only if we have no regular children
-      if (renderOutput?.props?.['children'] && hasNoChildren) {
+      if (
+        hasNoChildren &&
+        renderOutput.props &&
+        element.atom?.current.allowCustomTextInjection
+      ) {
         children = makeChildrenPropElement(renderOutput.props)
       }
 

--- a/libs/frontend/modules/renderer/src/element/wrapper.utils.ts
+++ b/libs/frontend/modules/renderer/src/element/wrapper.utils.ts
@@ -36,7 +36,11 @@ export const getReactComponent = (renderOutput: IRenderOutput) =>
   renderOutput.atomType ? getAtom(renderOutput.atomType) ?? Fragment : Fragment
 
 export const makeChildrenPropElement = (props: IPropData) =>
-  React.createElement(Fragment, {}, props['children'])
+  React.createElement('span', {
+    dangerouslySetInnerHTML: {
+      __html: props?.['CustomText'],
+    },
+  })
 
 export const childrenAreEmpty = (children: any) =>
   !children || (Array.isArray(children) && !children.length)

--- a/libs/frontend/modules/renderer/src/element/wrapper.utils.ts
+++ b/libs/frontend/modules/renderer/src/element/wrapper.utils.ts
@@ -38,7 +38,7 @@ export const getReactComponent = (renderOutput: IRenderOutput) =>
 export const makeChildrenPropElement = (props: IPropData) =>
   React.createElement('span', {
     dangerouslySetInnerHTML: {
-      __html: props?.['CustomText'],
+      __html: props?.['customText'],
     },
   })
 

--- a/libs/frontend/modules/renderer/src/renderer.model.ts
+++ b/libs/frontend/modules/renderer/src/renderer.model.ts
@@ -247,7 +247,7 @@ export class Renderer
   ): ArrayOrSingle<IRenderOutput> => {
     let props = mergeProps(
       element.__metadataProps,
-      element.safePropsData,
+      element.props?.values,
       extraProps,
       this.extraElementProps.getForElement(element.id),
     )

--- a/libs/frontend/modules/renderer/src/test/renderAtomPipe.spec.ts
+++ b/libs/frontend/modules/renderer/src/test/renderAtomPipe.spec.ts
@@ -9,7 +9,7 @@ describe('RenderAtomPipe', () => {
   it('should render element atom', async () => {
     const text = 'a text to render'
     data.elementToRender.setAtom(atomRef(data.textAtom.id))
-    data.elementToRender.props?.set('text', text)
+    data.elementToRender.props?.set('customText', text)
 
     const output = data.renderer.renderElement(data.elementToRender)
     const { findByText } = render(output)

--- a/libs/frontend/modules/renderer/src/test/setup/setupTest.ts
+++ b/libs/frontend/modules/renderer/src/test/setup/setupTest.ts
@@ -8,7 +8,6 @@ import {
 } from '@codelab/frontend/modules/component'
 import {
   Element,
-  elementRef,
   ElementService,
   ElementTree,
   Prop,
@@ -125,7 +124,7 @@ export const setupTestForRenderer = (pipes: Array<RenderPipeClass> = []) => {
         id: v4(),
         data: frozen({
           componentProp: 'original',
-          text: "I'm a component",
+          customText: "I'm a component",
         }),
       }),
     })
@@ -159,13 +158,6 @@ export const setupTestForRenderer = (pipes: Array<RenderPipeClass> = []) => {
           },
         }),
       }),
-      children: objectMap([
-        [data.elementToRender02.id, elementRef(data.elementToRender02)],
-        [
-          data.componentInstanceElementToRender.id,
-          elementRef(data.componentInstanceElementToRender),
-        ],
-      ]),
       propTransformationJs: `
   // Write a transformer function, you get the input props as parameter
   // All returned props will get merged with the original ones

--- a/libs/frontend/modules/renderer/src/test/typedValueTranformers.spec.ts
+++ b/libs/frontend/modules/renderer/src/test/typedValueTranformers.spec.ts
@@ -54,7 +54,7 @@ describe('RenderService', () => {
     const { findByText } = render(someNode())
 
     expect(
-      await findByText(data.componentRootElement.props?.get('text')),
+      await findByText(data.componentRootElement.props?.get('customText')),
     ).toBeInTheDocument()
   })
 
@@ -72,7 +72,7 @@ describe('RenderService', () => {
     ) as IRenderOutput
 
     const { someNode } = props as any
-    const { findByText } = render(someNode({ text: 'new text' }))
+    const { findByText } = render(someNode({ customText: 'new text' }))
 
     expect(await findByText('new text')).toBeInTheDocument()
   })

--- a/libs/frontend/platform/atoms/src/custom/text/Text.tsx
+++ b/libs/frontend/platform/atoms/src/custom/text/Text.tsx
@@ -1,13 +1,9 @@
-import { Nullish } from '@codelab/shared/abstract/types'
+import { IPropData } from '@codelab/shared/abstract/core'
 import { List as AntList, ListProps } from 'antd'
-import React from 'react'
+import React, { Fragment } from 'react'
 
-export interface TextProps {
-  text: Nullish<string>
-}
-
-export const Text = ({ text }: TextProps) => {
-  return <>{text ?? ''}</>
+export const Text = (props: IPropData) => {
+  return React.createElement(Fragment, props)
 }
 
 export const List = ({

--- a/libs/frontend/platform/atoms/src/custom/text/Text.tsx
+++ b/libs/frontend/platform/atoms/src/custom/text/Text.tsx
@@ -3,7 +3,7 @@ import { List as AntList, ListProps } from 'antd'
 import React, { Fragment } from 'react'
 
 export const Text = (props: IPropData) => {
-  return React.createElement(Fragment, props)
+  return React.createElement(Fragment, {}, props['children'])
 }
 
 export const List = ({

--- a/libs/shared/abstract/core/src/domain/atom/atom.interface.ts
+++ b/libs/shared/abstract/core/src/domain/atom/atom.interface.ts
@@ -1,7 +1,7 @@
 import { IEntity, Nullish } from '@codelab/shared/abstract/types'
 import { Ref } from 'mobx-keystone'
 import { ITag } from '../tag'
-import { IAnyType, IInterfaceType } from '../type'
+import { IAnyType } from '../type'
 import { IAtomDTO } from './atom.dto.interface'
 import { IAtomType } from './atom-type.enum'
 
@@ -10,6 +10,7 @@ export interface IAtom extends IEntity {
   type: IAtomType
   tags: Array<Ref<ITag>>
   api: Ref<IAnyType>
+  allowCustomTextInjection: boolean
   updateCache(atom: any): void
 }
 

--- a/libs/shared/abstract/core/src/domain/element/element.model.interface.ts
+++ b/libs/shared/abstract/core/src/domain/element/element.model.interface.ts
@@ -28,7 +28,6 @@ export interface IElement extends INodeType<ELEMENT_NODE_TYPE> {
   customCss: Nullable<string>
   guiCss: Nullable<string>
   props?: Nullable<IProp>
-  safePropsData?: IPropData
   atom: Nullable<Ref<IAtom>>
   orderInParent: Nullable<number>
   hooks: Array<IHook>


### PR DESCRIPTION
## Description (Optional)

This PR injects custom text (html) into elements by injecting a `<span>` element with it's inner html set to the custom text. This feature is enabled only for a selected number of Atoms since some atoms do not accept children.

https://user-images.githubusercontent.com/51242349/184231157-85b2cc59-1693-4af6-8a96-5b86bd96f1c3.mp4

## Related Issue(s)

Fixes #1709
