### PR TITLE
Stuck panel border fix

### DIFF
--- a/libs/frontend/view/components/resizable/useResizable.ts
+++ b/libs/frontend/view/components/resizable/useResizable.ts
@@ -119,6 +119,7 @@ export const useResizable = ({
     xDragHandleProps: {
       onDrag: handleXDrag,
       style: {
+        translateX: '0px !important',
         cursor: 'col-resize',
       },
       onDragEnd: () => setIsDraggingX(false),
@@ -129,6 +130,8 @@ export const useResizable = ({
     xyDragHandleProps: {
       onDrag: handleXYDrag,
       style: {
+        translateX: '0px !important',
+        translateY: '0px !important',
         cursor: 'nwse-resize',
       },
       onDragEnd: () => {
@@ -145,6 +148,7 @@ export const useResizable = ({
     yDragHandleProps: {
       onDrag: handleYDrag,
       style: {
+        translateY: '0px !important',
         cursor: 'row-resize',
       },
       onDragEnd: () => setIsDraggingY(false),


### PR DESCRIPTION
## Description

After window resize, aparently, motion decides to translate the border with the same delta when resizing a panel. The current solution is just forcing 0px translation.

## Related Issue

Fixes #1668 
