### PR TITLE
1755 disallow deleting root element

### DIFF
--- a/libs/frontend/modules/builder/src/hooks/useBuilderHotkeys.ts
+++ b/libs/frontend/modules/builder/src/hooks/useBuilderHotkeys.ts
@@ -35,7 +35,7 @@ export const useBuilderHotkeys = ({
       }
     },
     { enabled: !!selectedNode },
-    [],
+    [selectedNode],
   )
   useHotkeys(
     'esc',

--- a/libs/frontend/modules/builder/src/hooks/useBuilderHotkeys.ts
+++ b/libs/frontend/modules/builder/src/hooks/useBuilderHotkeys.ts
@@ -1,5 +1,9 @@
 import { elementRef } from '@codelab/frontend/modules/element'
-import { IBuilderService, IElementService } from '@codelab/shared/abstract/core'
+import {
+  IBuilderService,
+  IElementService,
+  isElement,
+} from '@codelab/shared/abstract/core'
 import { useHotkeys } from 'react-hotkeys-hook'
 
 type UseBuilderHotkeysProps = Pick<
@@ -22,7 +26,12 @@ export const useBuilderHotkeys = ({
     'del,backspace',
     () => {
       if (selectedNode) {
-        deleteModal.open(elementRef(selectedNode.id))
+        const isRootElement =
+          isElement(selectedNode) && !selectedNode.parentElement
+
+        if (!isRootElement) {
+          deleteModal.open(elementRef(selectedNode.id))
+        }
       }
     },
     { enabled: !!selectedNode },


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->
fix: disable deleting the root element using hotkeys

## Description (Optional)

<!-- This is a short description on the Pull Request -->
This PR disables deleting the root element of a page using hotkeys. 
It also includes fix for the bug where pressing `del` on a non-root element would open delete modal for the root element.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1775 @melhamin make sure this format
