### PR TITLE
fix: prop data left over after delete

### DIFF
--- a/libs/frontend/modules/element/src/store/element.service.ts
+++ b/libs/frontend/modules/element/src/store/element.service.ts
@@ -22,6 +22,7 @@ import {
   IUpdatePropMapBindingDTO,
 } from '@codelab/shared/abstract/core'
 import { IEntity, Nullable } from '@codelab/shared/abstract/types'
+import { omit } from 'lodash'
 import {
   _async,
   _await,
@@ -792,8 +793,7 @@ export class ElementService
     )
 
     const promises = elementsThatUseTheProp.map((element) => {
-      const currentProps = { ...element.props?.data }
-      const { [propKey]: removedProp, ...updatedProps } = currentProps.data
+      const updatedProps = omit(element.props?.data, propKey)
 
       return this.patchElement(element, {
         props: {

--- a/libs/frontend/modules/type/src/store/type.service.ts
+++ b/libs/frontend/modules/type/src/store/type.service.ts
@@ -1,3 +1,4 @@
+import { getElementService } from '@codelab/frontend/presenter/container'
 import { ModalService, throwIfUndefined } from '@codelab/frontend/shared/utils'
 import { TypeBaseWhere } from '@codelab/shared/abstract/codegen'
 import type {
@@ -65,6 +66,11 @@ export class TypeService
   @computed
   get typesList() {
     return [...this.types.values()]
+  }
+
+  @computed
+  get elementService() {
+    return getElementService(this)
   }
 
   type(id: string) {
@@ -347,6 +353,13 @@ export class TypeService
 
     const input = { where: { id: fieldId }, interfaceId }
     const res = yield* _await(fieldApi.DeleteField(input))
+
+    yield* _await(
+      this.elementService.removeDeletedPropDataFromElements(
+        interfaceType,
+        field.key,
+      ),
+    )
 
     // Returns current edges, not deleted edges
     // const deletedField =

--- a/libs/shared/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/shared/abstract/core/src/domain/element/element.service.interface.ts
@@ -15,6 +15,7 @@ import {
   IPropMapBinding,
   IUpdatePropMapBindingDTO,
 } from '../prop'
+import { IInterfaceType } from '../type/types/interface-type/interface-type.interface'
 import { IAuth0Id } from '../user'
 import {
   ICreateElementDTO,
@@ -123,4 +124,8 @@ export interface IElementService
    * Get all descendant elements
    */
   getDescendants(root: IElementRef): Promise<Array<IElement>>
+  removeDeletedPropDataFromElements(
+    interfaceType: IInterfaceType,
+    propKey: string,
+  ): Promise<void>
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)
This PR fixes prop data left over in the elements after the prop is deleted from an atom API. 
<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1758 
