### PR TITLE
fix: remove update cache fn from element.service

### DIFF
--- a/libs/frontend/modules/element/src/store/element.service.ts
+++ b/libs/frontend/modules/element/src/store/element.service.ts
@@ -246,10 +246,7 @@ export class ElementService
     this: ElementService,
     element: Pick<IElement, 'id'>,
     input: ElementUpdateInput,
-    shouldUpdateCache = true,
   ) {
-    console.log({ shouldUpdateCache })
-
     const {
       updateElements: {
         elements: [updatedElement],
@@ -271,11 +268,7 @@ export class ElementService
       throw new Error('Element not found')
     }
 
-    if (shouldUpdateCache) {
-      return elementFromCache.writeCache(updatedElement)
-    }
-
-    return elementFromCache
+    return elementFromCache.writeCache(updatedElement)
   })
 
   @modelFlow


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)
This is an add-on parameter that skips the updating cache when we want to make multiple changes to an element, and bulk updates the cache. It's not used anymore as we have a bulk update function that takes multiple mutations, and we can provide our own update cache function

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

#1800 
