### PR TITLE
refactor: init component tree on builder, pass only components to init

### DIFF
--- a/apps/builder-e2e/src/e2e/component.cy.ts
+++ b/apps/builder-e2e/src/e2e/component.cy.ts
@@ -121,7 +121,6 @@ describe('Component CRUD', () => {
   describe('Add elements to component', () => {
     it('should be able to add elements to the component', () => {
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(waitTimeout)
       cy.get(`[title="${NEW_COMP_NAME}"]`)
         .closest('div')
         .find('.ant-tree-switcher_close')
@@ -156,6 +155,29 @@ describe('Component CRUD', () => {
           cy.get('#Builder').find('.ant-btn').should('exist')
           cy.get('#Builder').find('.ant-typography').should('exist')
         })
+    })
+  })
+  describe('Get component', () => {
+    it('should render component items correctly', () => {
+      cy.reload()
+
+      // expand components list
+      cy.get('[title="Components"]')
+        .parent()
+        .find('.ant-tree-switcher_close')
+        .click()
+
+      // the 1 is on the element tree
+      cy.findAllByText(NEW_COMP_NAME).should('have.length', 2)
+      cy.findAllByText(NEW_COMP_NAME).eq(1).click()
+
+      // the 2 is the component builder tree
+      cy.findAllByText(NEW_COMP_NAME).should('have.length', 3)
+      cy.findAllByText(NEW_COMP_NAME).eq(2).click()
+
+      // the 3 is root of the component on component builder tree
+      cy.findByText(CHILD_BUTTON).should('exist')
+      cy.findByText(CHILD_TEXT).should('exist')
     })
   })
 

--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -36,14 +36,11 @@ import { useAsync } from 'react-use'
 const PageBuilder: CodelabPage = observer(() => {
   const {
     appService,
-    storeService,
-    pageService,
     componentService,
     typeService,
     builderRenderService,
     elementService,
     builderService,
-    userService,
   } = useStore()
 
   const router = useRouter()
@@ -91,7 +88,12 @@ const PageBuilder: CodelabPage = observer(() => {
       codeMirrorTypes,
     })
 
-    components.map((component) => componentService.writeCache(component))
+    const hydratedComponents = components.map((component) =>
+      componentService.writeCache(component),
+    )
+
+    const hydratedComponentsWithElementTree =
+      await componentService.loadComponentTrees(hydratedComponents)
 
     /**
      *
@@ -119,7 +121,7 @@ const PageBuilder: CodelabPage = observer(() => {
       providerTree: null,
       store,
       types,
-      components,
+      components: hydratedComponentsWithElementTree,
       renderer,
     }
   }, [])

--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx
@@ -67,8 +67,12 @@ const PageRenderer: CodelabPage<any> = observer(() => {
      * components are needed to build pageElementTree
      *
      */
-    const components = await componentService.loadComponentTrees(
-      userService.auth0Id,
+    const components = await componentService.getAll({
+      owner: { auth0Id: userService.auth0Id },
+    })
+
+    const componentsWithElementTree = await componentService.loadComponentTrees(
+      components,
     )
 
     /**
@@ -99,7 +103,7 @@ const PageRenderer: CodelabPage<any> = observer(() => {
       providerTree: null,
       appStore,
       renderer,
-      components,
+      components: componentsWithElementTree,
       types,
     }
   }, [])

--- a/libs/backend/adapter/neo4j/src/selectionSets/componentSelectionSet.ts
+++ b/libs/backend/adapter/neo4j/src/selectionSets/componentSelectionSet.ts
@@ -3,8 +3,14 @@ export const componentSelectionSet = `{
   name
   rootElement {
     id
+    name
+  }
+  owner {
+    id
+    auth0Id
   }
   api {
     id
+    name
   }
 }`

--- a/libs/frontend/modules/component/src/store/component.service.ts
+++ b/libs/frontend/modules/component/src/store/component.service.ts
@@ -85,10 +85,8 @@ export class ComponentService
   @modelFlow
   loadComponentTrees = _async(function* (
     this: ComponentService,
-    auth0Id: IAuth0Id,
+    components: Array<IComponent>,
   ) {
-    const components = yield* _await(this.getAll({ owner: { auth0Id } }))
-
     const rootElement = new Element({
       id: 'components',
       name: 'Components',

--- a/libs/shared/abstract/core/src/domain/component/component.service.interface.ts
+++ b/libs/shared/abstract/core/src/domain/component/component.service.interface.ts
@@ -24,5 +24,5 @@ export interface IComponentService
   components: ObjectMap<IComponent>
   component(id: string): Maybe<IComponent>
   componentAntdNode: IBuilderDataNode
-  loadComponentTrees(auth0Id: IAuth0Id): Promise<any>
+  loadComponentTrees(components: Array<IComponent>): Promise<any>
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1828 
